### PR TITLE
feat: add support to `dotnet restore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ nx g @bbaia/nx-dotnet-core:new app webapi api --unitTestTemplate nunit
 
 ### Manage a project
 
+- Run `nx restore api` to restore the dependencies and tools of the project.
 - Run `nx serve api` to serve the app. The app will automatically reload if you change any of the source files.
 - Run `nx build api` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
 - Run `nx test api` to execute the unit tests via `nunit`. Use the `--watch` flag to watch files for changes and rerun tests.

--- a/e2e/nx-dotnet-core-e2e/tests/new.spec.ts
+++ b/e2e/nx-dotnet-core-e2e/tests/new.spec.ts
@@ -31,6 +31,9 @@ describe('new e2e', () => {
     const extensionsJson = readJson('.vscode/extensions.json');
     expect(extensionsJson.recommendations).toContain('ms-dotnettools.csharp');
 
+    const packageJson = readJson('package.json');
+    expect(packageJson.scripts.postinstall).toEqual('nx restore --all');
+
     const result = await runNxCommandAsync(`build ${plugin}`);
     expect(() =>
       checkFilesExist(
@@ -58,6 +61,9 @@ describe('new e2e', () => {
 
     const extensionsJson = readJson('.vscode/extensions.json');
     expect(extensionsJson.recommendations).toContain('ms-dotnettools.csharp');
+
+    const packageJson = readJson('package.json');
+    expect(packageJson.scripts.postinstall).toEqual('nx restore --all');
 
     const result = await runNxCommandAsync(`build ${plugin}`);
     expect(() =>

--- a/e2e/nx-dotnet-core-e2e/tests/new.spec.ts
+++ b/e2e/nx-dotnet-core-e2e/tests/new.spec.ts
@@ -38,7 +38,7 @@ describe('new e2e', () => {
         `dist/packages/${plugin}/web.config`,
       ),
     ).not.toThrow();
-  }, 50000);
+  }, 60000);
 
   it(`should create new library based on 'classlib' template`, async () => {
     const plugin = uniq('lib');
@@ -63,7 +63,7 @@ describe('new e2e', () => {
     expect(() =>
       checkFilesExist(`dist/packages/${plugin}/${names(plugin).className}.dll`),
     ).not.toThrow();
-  }, 50000);
+  }, 60000);
 
   describe('--directory', () => {
     it('should create src in the specified directory', async () => {
@@ -80,7 +80,7 @@ describe('new e2e', () => {
           `apps/subdir/${plugin}/README.md`,
         ),
       ).not.toThrow();
-    }, 50000);
+    }, 60000);
   });
 
   describe('--tags', () => {
@@ -92,7 +92,7 @@ describe('new e2e', () => {
       );
       const nxJson = readJson('nx.json');
       expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-    }, 50000);
+    }, 60000);
   });
 
   describe('--unitTestTemplate', () => {
@@ -115,6 +115,6 @@ describe('new e2e', () => {
 
       const result = await runNxCommandAsync(`test ${plugin}`);
       expect(result.stdout).toContain('Passed!');
-    }, 50000);
+    }, 90000);
   });
 });

--- a/packages/nx-dotnet-core/executors.json
+++ b/packages/nx-dotnet-core/executors.json
@@ -1,6 +1,11 @@
 {
   "$schema": "http://json-schema.org/schema",
   "executors": {
+    "restore": {
+      "implementation": "./src/executors/restore/executor",
+      "schema": "./src/executors/restore/schema.json",
+      "description": "restore executor"
+    },
     "serve": {
       "implementation": "./src/executors/serve/executor",
       "schema": "./src/executors/serve/schema.json",

--- a/packages/nx-dotnet-core/src/executors/build/executor.spec.ts
+++ b/packages/nx-dotnet-core/src/executors/build/executor.spec.ts
@@ -11,6 +11,8 @@ describe('Build Executor', () => {
     const options: BuildExecutorSchema = {
       project: 'my-app',
       outputPath: 'dist/my-app',
+      configuration: 'DEBUG',
+      noRestore: false,
     };
     const output = await executor(options);
     expect(output.success).toBe(true);
@@ -18,7 +20,8 @@ describe('Build Executor', () => {
     expect(dotnet.publish).toBeCalledWith(
       options.project,
       options.outputPath,
-      undefined,
+      options.configuration,
+      options.noRestore,
     );
   });
 });

--- a/packages/nx-dotnet-core/src/executors/build/executor.ts
+++ b/packages/nx-dotnet-core/src/executors/build/executor.ts
@@ -4,6 +4,6 @@ import { BuildExecutorSchema } from './schema';
 export default async function runExecutor(
   options: BuildExecutorSchema,
 ): Promise<{ success: boolean }> {
-  const { project, outputPath, configuration } = options;
-  return dotnet.publish(project, outputPath, configuration);
+  const { project, outputPath, configuration, noRestore } = options;
+  return dotnet.publish(project, outputPath, configuration, noRestore);
 }

--- a/packages/nx-dotnet-core/src/executors/build/schema.d.ts
+++ b/packages/nx-dotnet-core/src/executors/build/schema.d.ts
@@ -2,4 +2,5 @@ export interface BuildExecutorSchema {
   project: string;
   outputPath: string;
   configuration?: string;
+  noRestore?: boolean;
 }

--- a/packages/nx-dotnet-core/src/executors/build/schema.json
+++ b/packages/nx-dotnet-core/src/executors/build/schema.json
@@ -16,6 +16,11 @@
     "configuration": {
       "type": "string",
       "description": "The configuration to build for. The default for most projects is 'Debug'."
+    },
+    "noRestore": {
+      "type": "boolean",
+      "description": "Do not restore the project before building your project.",
+      "default": false
     }
   },
   "required": ["project", "outputPath"]

--- a/packages/nx-dotnet-core/src/executors/restore/executor.spec.ts
+++ b/packages/nx-dotnet-core/src/executors/restore/executor.spec.ts
@@ -1,0 +1,19 @@
+import { dotnet } from '../../utils';
+import executor from './executor';
+import { RestoreExecutorSchema } from './schema';
+
+describe('Restore Executor', () => {
+  beforeEach(() => {
+    dotnet.restore = jest.fn(() => Promise.resolve({ success: true }));
+  });
+
+  it('should call dotnet restore', async () => {
+    const options: RestoreExecutorSchema = {
+      project: 'my-app',
+    };
+    const output = await executor(options);
+    expect(output.success).toBe(true);
+    expect(dotnet.restore).toBeCalledTimes(1);
+    expect(dotnet.restore).toBeCalledWith(options.project);
+  });
+});

--- a/packages/nx-dotnet-core/src/executors/restore/executor.ts
+++ b/packages/nx-dotnet-core/src/executors/restore/executor.ts
@@ -1,0 +1,9 @@
+import { dotnet } from '../../utils';
+import { RestoreExecutorSchema } from './schema';
+
+export default async function runExecutor(
+  options: RestoreExecutorSchema,
+): Promise<{ success: boolean }> {
+  const { project } = options;
+  return dotnet.restore(project);
+}

--- a/packages/nx-dotnet-core/src/executors/restore/schema.d.ts
+++ b/packages/nx-dotnet-core/src/executors/restore/schema.d.ts
@@ -1,0 +1,3 @@
+export interface RestoreExecutorSchema {
+  project: string;
+}

--- a/packages/nx-dotnet-core/src/executors/restore/schema.json
+++ b/packages/nx-dotnet-core/src/executors/restore/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "title": "Restore executor",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The project to restore. If a file is not specified, the command will search the current directory for one."
+    }
+  },
+  "required": ["project"]
+}

--- a/packages/nx-dotnet-core/src/executors/serve/executor.spec.ts
+++ b/packages/nx-dotnet-core/src/executors/serve/executor.spec.ts
@@ -10,10 +10,17 @@ describe('Serve Executor', () => {
   it('should call dotnet watch run', async () => {
     const options: ServeExecutorSchema = {
       project: 'my-app',
+      noRestore: true,
+      verbose: false,
     };
     const output = await executor(options);
     expect(output.success).toBe(true);
     expect(dotnet.watch).toBeCalledTimes(1);
-    expect(dotnet.watch).toBeCalledWith(options.project, 'run', undefined);
+    expect(dotnet.watch).toBeCalledWith(
+      options.project,
+      'run',
+      options.noRestore,
+      options.verbose,
+    );
   });
 });

--- a/packages/nx-dotnet-core/src/executors/serve/executor.ts
+++ b/packages/nx-dotnet-core/src/executors/serve/executor.ts
@@ -4,6 +4,6 @@ import { ServeExecutorSchema } from './schema';
 export default async function runExecutor(
   options: ServeExecutorSchema,
 ): Promise<{ success: boolean }> {
-  const { project, verbose } = options;
-  return dotnet.watch(project, 'run', verbose);
+  const { project, noRestore, verbose } = options;
+  return dotnet.watch(project, 'run', noRestore, verbose);
 }

--- a/packages/nx-dotnet-core/src/executors/serve/schema.d.ts
+++ b/packages/nx-dotnet-core/src/executors/serve/schema.d.ts
@@ -1,4 +1,5 @@
 export interface ServeExecutorSchema {
   project: string;
+  noRestore?: boolean;
   verbose?: boolean;
 }

--- a/packages/nx-dotnet-core/src/executors/serve/schema.json
+++ b/packages/nx-dotnet-core/src/executors/serve/schema.json
@@ -9,6 +9,11 @@
       "type": "string",
       "description": "The project to serve. If a file is not specified, the command will search the current directory for one."
     },
+    "noRestore": {
+      "type": "boolean",
+      "description": "Do not restore the project before serving your app.",
+      "default": false
+    },
     "verbose": {
       "type": "boolean",
       "description": "Show verbose output."

--- a/packages/nx-dotnet-core/src/executors/test/executor.spec.ts
+++ b/packages/nx-dotnet-core/src/executors/test/executor.spec.ts
@@ -12,23 +12,29 @@ describe('Test Executor', () => {
     const options: TestExecutorSchema = {
       project: 'my-app',
       watch: false,
+      noRestore: false,
     };
     const output = await executor(options);
     expect(output.success).toBe(true);
     expect(dotnet.test).toBeCalledTimes(1);
     expect(dotnet.watch).toBeCalledTimes(0);
-    expect(dotnet.test).toBeCalledWith(options.project);
+    expect(dotnet.test).toBeCalledWith(options.project, options.noRestore);
   });
 
   it('should call dotnet watch test', async () => {
     const options: TestExecutorSchema = {
       project: 'my-app',
       watch: true,
+      noRestore: false,
     };
     const output = await executor(options);
     expect(output.success).toBe(true);
     expect(dotnet.test).toBeCalledTimes(0);
     expect(dotnet.watch).toBeCalledTimes(1);
-    expect(dotnet.watch).toBeCalledWith(options.project, 'test');
+    expect(dotnet.watch).toBeCalledWith(
+      options.project,
+      'test',
+      options.noRestore,
+    );
   });
 });

--- a/packages/nx-dotnet-core/src/executors/test/executor.ts
+++ b/packages/nx-dotnet-core/src/executors/test/executor.ts
@@ -4,6 +4,8 @@ import { TestExecutorSchema } from './schema';
 export default async function runExecutor(
   options: TestExecutorSchema,
 ): Promise<{ success: boolean }> {
-  const { project, watch } = options;
-  return watch ? dotnet.watch(project, 'test') : dotnet.test(project);
+  const { project, watch, noRestore } = options;
+  return watch
+    ? dotnet.watch(project, 'test', noRestore)
+    : dotnet.test(project, noRestore);
 }

--- a/packages/nx-dotnet-core/src/executors/test/schema.d.ts
+++ b/packages/nx-dotnet-core/src/executors/test/schema.d.ts
@@ -1,4 +1,5 @@
 export interface TestExecutorSchema {
   project: string;
   watch: boolean;
+  noRestore?: boolean;
 }

--- a/packages/nx-dotnet-core/src/executors/test/schema.json
+++ b/packages/nx-dotnet-core/src/executors/test/schema.json
@@ -13,6 +13,11 @@
       "type": "boolean",
       "description": "Watch files for changes and rerun tests.",
       "default": false
+    },
+    "noRestore": {
+      "type": "boolean",
+      "description": "Do not restore the project before running tests.",
+      "default": false
     }
   },
   "required": ["project"]

--- a/packages/nx-dotnet-core/src/generators/new/files/README.md__template__
+++ b/packages/nx-dotnet-core/src/generators/new/files/README.md__template__
@@ -1,6 +1,10 @@
 # <%= name %>
 
 This <%= projectType %> was generated with [Nx](https://nx.dev) and the [.NET Core plugin](https://github.com/bbaia/nx-dotnet-core).
+
+## Restore
+
+Run `nx restore <%= name %>` to restore the dependencies and tools of the project.
 <% if (canServe) { %>
 
 ## Development server

--- a/packages/nx-dotnet-core/src/generators/new/generator.spec.ts
+++ b/packages/nx-dotnet-core/src/generators/new/generator.spec.ts
@@ -59,22 +59,26 @@ describe('new generator', () => {
       expect(tree.exists('apps/my-app/README.md')).toBeTruthy();
       expect(tree.read('apps/my-app/README.md').toString())
         .toMatchInlineSnapshot(`
-      "# my-app
+        "# my-app
 
-      This application was generated with [Nx](https://nx.dev) and the [.NET Core plugin](https://github.com/bbaia/nx-dotnet-core).
+        This application was generated with [Nx](https://nx.dev) and the [.NET Core plugin](https://github.com/bbaia/nx-dotnet-core).
+
+        ## Restore
+
+        Run \`nx restore my-app\` to restore the dependencies and tools of the project.
 
 
-      ## Development server
+        ## Development server
 
-      Run \`nx serve my-app\` to serve the app. The app will automatically reload if you change any of the source files.
+        Run \`nx serve my-app\` to serve the app. The app will automatically reload if you change any of the source files.
 
 
-      ## Build
+        ## Build
 
-      Run \`nx build my-app\` to build the project. The build artifacts will be stored in the \`dist/\` directory. Use the \`--prod\` flag for a production build.
+        Run \`nx build my-app\` to build the project. The build artifacts will be stored in the \`dist/\` directory. Use the \`--prod\` flag for a production build.
 
-      "
-    `);
+        "
+      `);
     });
 
     it('should update workspace.json', async () => {
@@ -94,6 +98,12 @@ describe('new generator', () => {
         sourceRoot: 'apps/my-app/src',
         tags: [],
         targets: {
+          restore: {
+            executor: '@bbaia/nx-dotnet-core:restore',
+            options: {
+              project: 'apps/my-app',
+            },
+          },
           build: {
             executor: '@bbaia/nx-dotnet-core:build',
             outputs: ['{options.outputPath}'],
@@ -135,6 +145,19 @@ describe('new generator', () => {
         'my-app': { tags: [] },
       });
     });
+
+    it('should update package.json', async () => {
+      const options: NewGeneratorSchema = {
+        type: 'app',
+        template: 'webapi',
+        name: 'my-app',
+      };
+
+      await generator(tree, options);
+
+      const packageJson = readJson(tree, '/package.json');
+      expect(packageJson.scripts.postinstall).toEqual('nx restore --all');
+    });
   });
 
   describe('library', () => {
@@ -171,17 +194,21 @@ describe('new generator', () => {
       expect(tree.exists('libs/my-lib/README.md')).toBeTruthy();
       expect(tree.read('libs/my-lib/README.md').toString())
         .toMatchInlineSnapshot(`
-      "# my-lib
+        "# my-lib
 
-      This library was generated with [Nx](https://nx.dev) and the [.NET Core plugin](https://github.com/bbaia/nx-dotnet-core).
+        This library was generated with [Nx](https://nx.dev) and the [.NET Core plugin](https://github.com/bbaia/nx-dotnet-core).
+
+        ## Restore
+
+        Run \`nx restore my-lib\` to restore the dependencies and tools of the project.
 
 
-      ## Build
+        ## Build
 
-      Run \`nx build my-lib\` to build the project. The build artifacts will be stored in the \`dist/\` directory. Use the \`--prod\` flag for a production build.
+        Run \`nx build my-lib\` to build the project. The build artifacts will be stored in the \`dist/\` directory. Use the \`--prod\` flag for a production build.
 
-      "
-    `);
+        "
+      `);
     });
 
     it('should update workspace.json', async () => {
@@ -201,6 +228,12 @@ describe('new generator', () => {
         sourceRoot: 'libs/my-lib/src',
         tags: [],
         targets: {
+          restore: {
+            executor: '@bbaia/nx-dotnet-core:restore',
+            options: {
+              project: 'libs/my-lib',
+            },
+          },
           build: {
             executor: '@bbaia/nx-dotnet-core:build',
             outputs: ['{options.outputPath}'],
@@ -235,6 +268,19 @@ describe('new generator', () => {
       expect(nxJson.projects).toEqual({
         'my-lib': { tags: [] },
       });
+    });
+
+    it('should update package.json', async () => {
+      const options: NewGeneratorSchema = {
+        type: 'lib',
+        template: 'classlib',
+        name: 'my-lib',
+      };
+
+      await generator(tree, options);
+
+      const packageJson = readJson(tree, '/package.json');
+      expect(packageJson.scripts.postinstall).toEqual('nx restore --all');
     });
   });
 
@@ -282,6 +328,10 @@ describe('new generator', () => {
         "# my-lib
 
         This library was generated with [Nx](https://nx.dev) and the [.NET Core plugin](https://github.com/bbaia/nx-dotnet-core).
+
+        ## Restore
+
+        Run \`nx restore my-lib\` to restore the dependencies and tools of the project.
 
 
         ## Build

--- a/packages/nx-dotnet-core/src/utils/dotnet-commands.spec.ts
+++ b/packages/nx-dotnet-core/src/utils/dotnet-commands.spec.ts
@@ -41,6 +41,14 @@ describe('dotnet commands', () => {
     expect(dotnet.spawn).toBeCalledWith(['sln', 'root', 'add', 'root/src']);
   });
 
+  it('restore', () => {
+    const result = dotnet.restore('root/src');
+
+    expect(result).resolves.toEqual({ success: true });
+    expect(dotnet.spawn).toBeCalledTimes(1);
+    expect(dotnet.spawn).toBeCalledWith(['restore', 'root/src']);
+  });
+
   it('watch run', () => {
     const result = dotnet.watch('root/src', 'run');
 
@@ -64,6 +72,21 @@ describe('dotnet commands', () => {
       '--project',
       'root/src',
       'test',
+    ]);
+  });
+
+  it('watch run --no-restore', () => {
+    const result = dotnet.watch('root/src', 'run', true);
+
+    expect(result).resolves.toEqual({ success: true });
+    expect(dotnet.spawn).toBeCalledTimes(1);
+    expect(dotnet.spawn).toBeCalledWith([
+      'watch',
+      '--project',
+      'root/src',
+      'run',
+      '--',
+      '--no-restore',
     ]);
   });
 
@@ -97,11 +120,39 @@ describe('dotnet commands', () => {
     ]);
   });
 
+  it('publish --no-restore', () => {
+    const result = dotnet.publish('root/src', 'dist/my-app', undefined, true);
+
+    expect(result).resolves.toEqual({ success: true });
+    expect(dotnet.spawn).toBeCalledTimes(1);
+    expect(dotnet.spawn).toBeCalledWith([
+      'publish',
+      '--nologo',
+      '--no-restore',
+      '--output',
+      'dist/my-app',
+      'root/src',
+    ]);
+  });
+
   it('test', () => {
     const result = dotnet.test('root/src');
 
     expect(result).resolves.toEqual({ success: true });
     expect(dotnet.spawn).toBeCalledTimes(1);
     expect(dotnet.spawn).toBeCalledWith(['test', '--nologo', 'root/src']);
+  });
+
+  it('test --no-restore', () => {
+    const result = dotnet.test('root/src', true);
+
+    expect(result).resolves.toEqual({ success: true });
+    expect(dotnet.spawn).toBeCalledTimes(1);
+    expect(dotnet.spawn).toBeCalledWith([
+      'test',
+      '--nologo',
+      '--no-restore',
+      'root/src',
+    ]);
   });
 });

--- a/packages/nx-dotnet-core/src/utils/dotnet-commands.ts
+++ b/packages/nx-dotnet-core/src/utils/dotnet-commands.ts
@@ -36,9 +36,14 @@ async function addProjectToSolution(
   return dotnet.spawn(['sln', solutionPath, 'add', projectPath]);
 }
 
+async function restore(project: string): Promise<{ success: boolean }> {
+  return dotnet.spawn(['restore', project]);
+}
+
 async function watch(
   project: string,
   command: 'run' | 'test',
+  noRestore = false,
   verbose = false,
 ): Promise<{ success: boolean }> {
   const args = ['watch'];
@@ -48,6 +53,10 @@ async function watch(
   args.push('--project');
   args.push(project);
   args.push(command);
+  if (noRestore) {
+    args.push('--');
+    args.push('--no-restore');
+  }
   return dotnet.spawn(args);
 }
 
@@ -55,8 +64,12 @@ async function publish(
   project: string,
   outputPath?: string,
   configuration?: string,
+  noRestore = false,
 ): Promise<{ success: boolean }> {
   const args = ['publish', '--nologo'];
+  if (noRestore) {
+    args.push('--no-restore');
+  }
   if (outputPath) {
     args.push('--output');
     args.push(outputPath);
@@ -69,8 +82,14 @@ async function publish(
   return dotnet.spawn(args);
 }
 
-async function test(project: string): Promise<{ success: boolean }> {
+async function test(
+  project: string,
+  noRestore = false,
+): Promise<{ success: boolean }> {
   const args = ['test', '--nologo'];
+  if (noRestore) {
+    args.push('--no-restore');
+  }
   args.push(project);
   return dotnet.spawn(args);
 }
@@ -80,6 +99,7 @@ export const dotnet = {
   new: dotnetNew,
   addProjectReference,
   addProjectToSolution,
+  restore,
   watch,
   publish,
   test,


### PR DESCRIPTION
Adds a new `restore` executor.
Calls `dotnet restore` on `npm install`.